### PR TITLE
Actor API partial cleanup

### DIFF
--- a/src/Circo.jl
+++ b/src/Circo.jl
@@ -8,7 +8,9 @@ include("formats/index.jl")
 include("bin/index.jl")
 include("execution/executionindex.jl")
 
-struct Machine
+abstract type AbstractMachine end
+
+struct Machine <: AbstractMachine
     service::SimpleComponentService
 end
 
@@ -19,11 +21,19 @@ function Machine(network::Network)
     return Machine(service)
 end
 
-function (machine::Machine)(data;rollout = true)
-    machine.service.wantless_scheduler(data;rollout = rollout)
+Machine() = Machine(Network([]))
+service(machine::AbstractMachine) = machine.service
+spawn(machine::AbstractMachine, component::Component)::ComponentId = spawn(service(machine), component)
+
+function (machine::AbstractMachine)(data;rollout = true)
+    service(machine).wantless_scheduler(data;rollout = rollout)
 end
 
-export Machine,
+function (machine::AbstractMachine)(message::AbstractMessage)
+    service(machine).actor_scheduler(message)
+end
+
+export Machine, service,
     Node, Input, connect, isconnected, inputto, Network, |, hasinput,
     issource,
 

--- a/src/components/interface/Component.jl
+++ b/src/components/interface/Component.jl
@@ -25,12 +25,15 @@ struct Message{BodyType} <: AbstractMessage
     targetid::ComponentId
     body::BodyType
 end
-
-NothingMessage = Message{Nothing}
-
 sender(m::AbstractMessage) = m.senderid::ComponentId
 target(m::AbstractMessage) = m.targetid::ComponentId
 body(m::AbstractMessage) = m.body
+
+struct NothingMessage <: AbstractMessage # As of julia 1.3 and my understanding, Message{Nothing} does not allow creating the outer constructor NothingMessage(senderid, targetid)
+    senderid::ComponentId
+    targetid::ComponentId
+end
+body(m::NothingMessage) = nothing
 
 function onmessage(service, component, message) end
 

--- a/test/actor/actortree.jl
+++ b/test/actor/actortree.jl
@@ -44,14 +44,12 @@ end
 
 @testset "Actor" begin
     @testset "Actor-Tree" begin
-        service = SimpleComponentService(nothing, nothing)
-        scheduler = SimpleActorScheduler([], service)
-        set_actor_scheduler!(service, scheduler)
+        machine = Machine()
         creator = TreeCreator()
-        spawn(service, creator)
-        startrequest = Start(0, id(creator), nothing)
+        spawn(machine, creator)
+        startrequest = Start(0, id(creator))
         for i in 1:10
-            scheduler(startrequest)
+            machine(startrequest)
             @test creator.responsecount == 2^i - 1
         end
     end


### PR DESCRIPTION
Work on #2 : Actor scheduling can directly accessed using Machine; NothingMessage constructor fix

The Actor struct creation needs some research (encapsulating into another struct at spawn() or using a macro?) so I postponed.
